### PR TITLE
fix(git): add missing Icon component

### DIFF
--- a/src/components/Icon/Link.js
+++ b/src/components/Icon/Link.js
@@ -1,0 +1,14 @@
+/* @flow */
+import styled from 'styled-components';
+
+import Link from '../Link';
+
+// override the Link component
+export default styled(Link)`
+  color: #fff;
+  font-size: 23px;
+  line-height: 25px;
+  position: relative;
+  top: 3px;
+  margin: 0 5px;
+`;

--- a/src/components/Icon/index.js
+++ b/src/components/Icon/index.js
@@ -1,0 +1,21 @@
+/* @flow */
+import FontAwesome from 'react-fontawesome';
+import React from 'react';
+import styled from 'styled-components';
+
+import type { IconProps } from './types';
+import Link from './Link';
+
+/**
+ * Renders a font-awesome based icon that's a link!
+ * 
+ * @param {IconProps} props
+ * @returns
+ */
+export default function Icon(props: IconProps) {
+  return (
+    <Link target='_blank' href={props.href}>
+      <FontAwesome name={props.name} />
+    </Link>
+  );
+}

--- a/src/components/Icon/types.js
+++ b/src/components/Icon/types.js
@@ -1,0 +1,5 @@
+/* @flow */
+export type IconProps = {
+  name: string,
+  href: string,
+};


### PR DESCRIPTION
For some reason, git was claiming this file was ignored (even though it appears in none of the ignore files). Force-adding it with this commit, brushing it off as a bug.